### PR TITLE
fix: update careers link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,6 +25,6 @@
       <a href="/" class="btn">HOME</a>
       <a target="_blank" href="https://github.com/provectus" class="btn">GITHUB</a>
       <a href="{{ "/contributions/" | relative_url}}" class="btn">CONTRIBUTIONS</a>
-      <a target="_blank" href="https://provectus.com/careers" class="btn">CAREERS</a>
+      <a target="_blank" href="https://careers.provectus.com/jobs/" class="btn">CAREERS</a>
       <a target="_blank" href="https://provectus.com/insights/" class="btn">BLOG</a>
     </section>


### PR DESCRIPTION
Header contains broken link 
<img width="1152" alt="image" src="https://user-images.githubusercontent.com/1210371/226349312-bea6a8b2-aff5-46d0-a130-de53e31a13ac.png">
so was replaces to correct
<img width="884" alt="image" src="https://user-images.githubusercontent.com/1210371/226349431-faf0da8a-03a5-4736-8c1f-495b92e772cd.png">
